### PR TITLE
Define android gradle plugin by extensions value

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath "com.android.tools.build:gradle:$rootProject.ext.androidGradlePlugin"
     }
 }
 


### PR DESCRIPTION
- [x] CR @brandonchinn 

Define `androidGradlePlugin` like this in the parent project's build.gradle and the android gradle plugin should stay in sync for each subproject.

```groovy
ext {
    androidGradlePlugin = "2.2.0"
}
```